### PR TITLE
Improvement - automatically version upgrade.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,21 @@
     <jacoco.version>0.6.3.201306030806</jacoco.version>
     <!-- Maven version requirement -->
     <maven.version>3.1.1</maven.version>
+
+    <!-- To allow work mvn versions:update-properties we should all versions store in properties.
+    Before run mvn versions:update-properties we can check what will happen
+    by running versions:display-plugin-updates
+    TODO add properties for all plugins -->
+
+    <android.version>3.8.1</android.version>
+    <cargo.varsion>1.4.5</cargo.varsion>
+    <appassembler.version>1.6</appassembler.version>
+    <aspectj.version>1.5</aspectj.version>
+    <cassandra.version>1.2.1-1</cassandra.version>
+    <gwt.version>2.5.1</gwt.version>
+    <keytool.version>1.3</keytool.version>
+    <nbm.version>3.11.1</nbm.version>
+
   </properties>
   <build>
     <extensions>
@@ -90,7 +105,7 @@
         <plugin>
           <groupId>com.jayway.maven.plugins.android.generation2</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>${android.version}</version>
         </plugin>
         <plugin>
           <groupId>com.mycila.maven-license-plugin</groupId>
@@ -308,7 +323,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
-          <version>1.4.5</version>
+          <version>${cargo.varsion}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.gmaven</groupId>
@@ -333,12 +348,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>appassembler-maven-plugin</artifactId>
-          <version>1.6</version>
+          <version>${appassembler.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>aspectj-maven-plugin</artifactId>
-          <version>1.5</version>
+          <version>${aspectj.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -358,7 +373,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cassandra-maven-plugin</artifactId>
-          <version>1.2.1-1</version>
+          <version>${cassandra.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -418,7 +433,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>${gwt.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -468,7 +483,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>keytool-maven-plugin</artifactId>
-          <version>1.3</version>
+          <version>${keytool.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -483,7 +498,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>nbm-maven-plugin</artifactId>
-          <version>3.11.1</version>
+          <version>${nbm.version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -676,6 +691,14 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <inherited>false</inherited>
+          <configuration>
+            <rulesUri>file://${project.basedir}/rule-set.xml</rulesUri>
+          </configuration>
       </plugin>
     </plugins>
   </build>

--- a/rule-set.xml
+++ b/rule-set.xml
@@ -1,0 +1,12 @@
+<ruleset comparisonMethod="maven"
+    xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+
+    <!-- more examples: http://mojo.codehaus.org/versions-maven-plugin/version-rules.html -->
+
+    <ignoreVersions>
+        <!-- gwt-maven-plugin release release candidate version with the following mask-->
+        <ignoreVersion type="regex">.*-rc\d*</ignoreVersion>
+    </ignoreVersions>
+
+</ruleset>


### PR DESCRIPTION
Store versions in properties allow us to use versions plugin to perform the update automatically.

After this change we can simply run:

```
mvn versions:display-plugin-updates 
```
- to see which plugins have newer versions

and the finally:

```
mvn versions:update-properties 
```
- to upgrade all plugins by one command

There is possibility to manage how versions are resolved by ruleset file.

If my idea is ok for you I can prepare change for the other plugins to store theirs versions in properties.
