### PR TITLE
More recent version of checkstyle and Pmd analyzers

### DIFF
--- a/changelog.asciidoc
+++ b/changelog.asciidoc
@@ -9,7 +9,8 @@ Changes done by Manfred Moser unless otherwise documented.
 === Version 2.5.1 or higher - upcoming
 
 * added  org.codehaus.mojo:javancss-maven-plugin:2.1 
-
+* added dependency for checkstyle 6.8.1
+* added dependency for pmd 5.3.2
 
 === Version 2.5.0 - 2015-06-09
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
     <jacoco.version>0.7.5.201505241946</jacoco.version>
     <!-- Maven version requirement -->
     <maven.version>3.2.1</maven.version>
+
+    <!-- maven checkstyle and pmd plugins for the most time use older version of wrapped analyzers -->
+    <!-- thanks to properties we can use: versions:display-property-updates -->
+    <checkstyle.version>6.8.1</checkstyle.version>
+    <pmd.version>5.3.2</pmd.version>
   </properties>
   <build>
     <extensions>
@@ -170,6 +175,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>2.15</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>${checkstyle.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -254,6 +266,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>3.4</version>
+          <dependencies>
+            <dependency>
+              <groupId>net.sourceforge.pmd</groupId>
+              <artifactId>pmd-core</artifactId>
+              <version>${pmd.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Maven checkstyle and pmd plugins for the most time use older version of wrapped analyzers.

My proposition is to add dependency to those tools, according to example: 
http://maven.apache.org/plugins/maven-checkstyle-plugin/examples/upgrading-checkstyle.html