### PR TITLE
Plugin updates

### DIFF
--- a/changelog.asciidoc
+++ b/changelog.asciidoc
@@ -8,15 +8,31 @@ Changes done by Manfred Moser unless otherwise documented.
 === Version 5.1.0+ - Upcoming
 
 * org.codehaus.mojo:tidy-maven-plugin to 1.0.0
-* biz.aQute.bnd:bnd-maven-plugin 3.1.0 -> 3.2.0
-* com.simpligility.maven.plugins:android-maven-plugin  4.4.1 -> 4.4.2
-* com.spotify:docker-maven-plugin 0.4.6 -> 0.4.10
+* biz.aQute.bnd:bnd-maven-plugin 3.1.0 -> 3.3.0
+* com.simpligility.maven.plugins:android-maven-plugin  4.4.1 -> 4.4.3
+* com.spotify:docker-maven-plugin 0.4.6 -> 0.4.13
 * maven-resources-plugin 2.7 -> 3.0.0
 * org.apache.rat:apache-rat-plugin 0.11 -> 0.12
 * org.codehaus.mojo:exec-maven-plugin 1.4.0 -> 1.5.0
 * org.codehaus.mojo:license-maven-plugi 1.8 -> 1.9
-* org.liquibase:liquibase-maven-plugin 3.5.0 -> 3.5.1
+* org.liquibase:liquibase-maven-plugin 3.5.0 -> 3.5.3
 * org.skife.maven:really-executable-jar-maven-plugin 1.4.1 -> 1.5.0
+* com.github.eirslett:frontend-maven-plugin 1.0 -> 1.1
+* com.github.maven-nar:nar-maven-plugin 3.4.0 -> 3.5.1
+* com.simpligility.maven.plugins:android-ndk-maven-plugin  1.1.1 -> 1.1.2
+* org.codehaus.cargo:cargo-maven2-plugin 1.4.19 -> 1.5.1
+* org.codehaus.mojo:appassembler-maven-plugin 1.10 -> 2.0.0
+* org.codehaus.mojo:build-helper-maven-plugin 1.10 -> 1.12
+* org.codehaus.mojo:cassandra-maven-plugin 2.1.7-1 -> 3.5
+* org.codehaus.mojo:clirr-maven-plugin 2.7 -> 2.8
+* org.codehaus.mojo:findbugs-maven-plugin 3.0.3 -> 3.0.4
+* org.codehaus.mojo:gwt-maven-plugin 2.7.0 -> 2.8.0
+* org.codehaus.mojo:jaxb2-maven-plugin 2.2 -> 2.3
+* org.codehaus.mojo:license-maven-plugin 1.9 -> 1.10
+* org.codehaus.mojo:versions-maven-plugin 2.2 -> 2.3
+* org.jacoco:jacoco-maven-plugin  0.7.6.201602180812 -> 0.7.7.201606060606
+* org.sonarsource.scanner.maven:sonar-maven-plugin 3.0.2 -> 3.2
+* org.springframework.boot:spring-boot-maven-plugin  1.3.2.RELEASE -> 1.4.1.RELEASE
 * your contributions could be here
 
 === Version 5.0.0 - 2016-04-26

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <codehaus.chronos.jmeter.version>1.1.0</codehaus.chronos.jmeter.version>
     <asciidoctor.version>1.5.3</asciidoctor.version>
     <!-- this version property is by convention also used for jacoco dependencies in projects using the plugin -->
-    <jacoco.version>0.7.6.201602180812</jacoco.version>
+    <jacoco.version>0.7.7.201606060606</jacoco.version>
     <!-- Maven version requirement -->
     <maven.version>3.2.1</maven.version>
   </properties>
@@ -78,7 +78,7 @@
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>br.com.ingenieux</groupId>
@@ -98,7 +98,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.1</version>
         </plugin>
         <plugin>
           <groupId>com.github.marschall</groupId>
@@ -108,22 +108,22 @@
         <plugin>
           <groupId>com.github.maven-nar</groupId>
           <artifactId>nar-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.1</version>
         </plugin>
         <plugin>
           <groupId>com.simpligility.maven.plugins</groupId>
           <artifactId>android-maven-plugin</artifactId>
-          <version>4.4.2</version>
+          <version>4.4.3</version>
         </plugin>
         <plugin>
           <groupId>com.simpligility.maven.plugins</groupId>
           <artifactId>android-ndk-maven-plugin</artifactId>
-          <version>1.1.1</version>
+          <version>1.1.2</version>
         </plugin>
         <plugin>
           <groupId>com.spotify</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.4.10</version>
+          <version>0.4.13</version>
         </plugin>
         <plugin>
           <groupId>com.mycila.maven-license-plugin</groupId>
@@ -380,7 +380,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven2-plugin</artifactId>
-          <version>1.4.19</version>
+          <version>1.5.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.gmaven</groupId>
@@ -405,7 +405,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>appassembler-maven-plugin</artifactId>
-          <version>1.10</version>
+          <version>2.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -420,7 +420,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.10</version>
+          <version>1.12</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -430,7 +430,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cassandra-maven-plugin</artifactId>
-          <version>2.1.7-1</version>
+          <version>3.5</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -455,7 +455,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.8</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -480,7 +480,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.3</version>
+          <version>3.0.4</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -495,7 +495,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>2.7.0</version>
+          <version>2.8.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -520,7 +520,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>jaxb2-maven-plugin</artifactId>
-          <version>2.2</version>
+          <version>2.3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -565,7 +565,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>1.9</version>
+          <version>1.10</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -655,7 +655,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.2</version>
+          <version>2.3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -715,7 +715,7 @@
         <plugin>
           <groupId>org.liquibase</groupId>
           <artifactId>liquibase-maven-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.5.3</version>
         </plugin>
         <plugin>
           <groupId>org.skife.maven</groupId>
@@ -725,7 +725,7 @@
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.2</version>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
@@ -755,7 +755,7 @@
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>1.3.2.RELEASE</version>
+          <version>1.4.1.RELEASE</version>
         </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>


### PR DESCRIPTION
* biz.aQute.bnd:bnd-maven-plugin 3.2.0 -> 3.3.0
* com.simpligility.maven.plugins:android-maven-plugin  4.4.2 -> 4.4.3
* com.spotify:docker-maven-plugin 0.4.10 -> 0.4.13
* org.liquibase:liquibase-maven-plugin 3.5.1 -> 3.5.3
* com.github.eirslett:frontend-maven-plugin 1.0 -> 1.1
* com.github.maven-nar:nar-maven-plugin 3.4.0 -> 3.5.1
* com.simpligility.maven.plugins:android-ndk-maven-plugin  1.1.1 -> 1.1.2
* org.codehaus.cargo:cargo-maven2-plugin 1.4.19 -> 1.5.1
* org.codehaus.mojo:appassembler-maven-plugin 1.10 -> 2.0.0
* org.codehaus.mojo:build-helper-maven-plugin 1.10 -> 1.12
* org.codehaus.mojo:cassandra-maven-plugin 2.1.7-1 -> 3.5
* org.codehaus.mojo:clirr-maven-plugin 2.7 -> 2.8
* org.codehaus.mojo:findbugs-maven-plugin 3.0.3 -> 3.0.4
* org.codehaus.mojo:gwt-maven-plugin 2.7.0 -> 2.8.0
* org.codehaus.mojo:jaxb2-maven-plugin 2.2 -> 2.3
* org.codehaus.mojo:license-maven-plugin 1.9 -> 1.10
* org.codehaus.mojo:versions-maven-plugin 2.2 -> 2.3
* org.jacoco:jacoco-maven-plugin  0.7.6.201602180812 -> 0.7.7.201606060606
* org.sonarsource.scanner.maven:sonar-maven-plugin 3.0.2 -> 3.2
* org.springframework.boot:spring-boot-maven-plugin  1.3.2.RELEASE -> 1.4.1.RELEASE